### PR TITLE
add Dec() method to decrement

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -3,4 +3,5 @@ package counter
 type Counter interface {
 	Get() uint64
 	Inc()
+	Dec()
 }

--- a/counter_atomic.go
+++ b/counter_atomic.go
@@ -14,6 +14,11 @@ func (c *CounterAtomic) Inc() {
 	atomic.AddUint64(&c.count, 1)
 }
 
+// Decrement counter
+func (c *CounterAtomic) Dec() {
+	atomic.AddUint64(&c.count, ^uint64(0))
+}
+
 // Get current counter value
 func (c *CounterAtomic) Get() uint64 {
 	return atomic.LoadUint64(&c.count)

--- a/counter_channel.go
+++ b/counter_channel.go
@@ -23,9 +23,12 @@ func NewCounterChannel() *CounterChannel {
 			select {
 			// Reading from readCh is equivalent to reading count.
 			case c.readCh <- count:
-			// Writing to the writeCh increments count.
-			case <-c.writeCh:
-				count++
+			case delta := <-c.writeCh:
+				if delta < 0 && count > 0 {
+					count--
+				} else if delta > 0 {
+					count++
+				}
 			}
 		}
 	}()
@@ -33,10 +36,16 @@ func NewCounterChannel() *CounterChannel {
 	return c
 }
 
-// Increment counter by pushing an arbitrary int to the write channel.
+// Increment counter by pushing 1 to the write channel.
 func (c *CounterChannel) Inc() {
 	c.check()
 	c.writeCh <- 1
+}
+
+// Decrement counter by pushing -1 to the write channel.
+func (c *CounterChannel) Dec() {
+	c.check()
+	c.writeCh <- -1
 }
 
 // Get current counter value from the read channel.

--- a/counter_mutex.go
+++ b/counter_mutex.go
@@ -26,3 +26,9 @@ func (c *CounterMutex) Get() (ret uint64) {
 	c.rw.RUnlock()
 	return
 }
+
+func (c *CounterMutex) Dec() {
+	c.rw.Lock()
+	defer c.rw.Unlock()
+	c.count--
+}

--- a/counter_test.go
+++ b/counter_test.go
@@ -45,7 +45,7 @@ func test1(cnt counter.Counter, t *testing.T) {
 	val := cnt.Get()
 
 	if val != 0 {
-		t.Errorf("Inital value: %d\nexpected: 0", val)
+		t.Errorf("Initial value: %d\nexpected: 0", val)
 	}
 
 	cnt.Inc()
@@ -58,10 +58,21 @@ func test1(cnt counter.Counter, t *testing.T) {
 		t.Errorf("After 3x Inc() value: %d\nexpected: 3", val)
 	}
 
+	cnt.Dec()
+
 	val = cnt.Get()
 
-	if val != 3 {
-		t.Errorf("After 3x Inc() + 1 Get() value: %d\nexpected: 3", val)
+	if val != 2 {
+		t.Errorf("After 3x Inc() and 1x Dec() value: %d\nexpected: 2", val)
+	}
+
+	cnt.Dec()
+	cnt.Dec()
+
+	val = cnt.Get()
+
+	if val != 0 {
+		t.Errorf("After 3x Inc() and 3x Dec() value: %d\nexpected: 0", val)
 	}
 }
 


### PR DESCRIPTION
Written with the help of [sourcegraph cody](https://sourcegraph.com/docs/cody).

- [x] add Dec() to Counter interface 
- [x] implement Dec() for the 3 counter types
- [x] cover Dec() in tests
- [ ] deal with negative counter results (change type or disallow)

Interestingly the negative result issue only cropped up the 2nd time I asked Cody to fix the implementation of CounterChannel.